### PR TITLE
Improve metadata and file management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-data/
-log/
 private/
-results/
 *.sublime*
 
 # Operating system junk

--- a/camelid/tests/test_camelidenv.py
+++ b/camelid/tests/test_camelidenv.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 '''Unit tests for camelid run environment.'''
 
+import os
+
 from camelid.run import CamelidEnv
 
 
 def test_camelidenv():
     env = CamelidEnv(project='test')
+    assert os.path.exists(env.log_file)
+    env.clean_logs()
+    assert not os.path.exists(env.log_file)


### PR DESCRIPTION
- `current_update` time stamp is now assigned immediately after the PubChem search is submitted.
- Excel export now includes count of total compounds and compounds with CASRN.
- `-c` option now clears old logs too.
